### PR TITLE
Fix: Issue with HSL/HSV values with `1%` component

### DIFF
--- a/lib/kodachroma/helpers/bounders.rb
+++ b/lib/kodachroma/helpers/bounders.rb
@@ -41,6 +41,8 @@ module Kodachroma
       # @param n [Numeric, String]
       # @return  [String, Float]
       def to_percentage(n)
+        return n.to_f if n.is_a?(String) && n.include?('%')
+
         n = n.to_f
         n = "#{ n * 100 }%" if n <= 1
         n

--- a/spec/kodachroma/paint_spec.rb
+++ b/spec/kodachroma/paint_spec.rb
@@ -51,6 +51,18 @@ describe Kodachroma do
       it 'creates a color' do
         expect(described_class.paint('hsl(120, 100%, 50%)')).to be_a(Kodachroma::Color)
       end
+
+      it 'parses the rgb properly' do
+        result = described_class.paint('hsl(120, 100%, 50%)')
+        expect(result.rgb.r).to eql(0)
+        expect(result.rgb.g).to eql(255.0)
+        expect(result.rgb.b).to eql(0)
+
+        result = described_class.paint('hsl(60 1% 34%)')
+        expect(result.rgb.r.round).to eql(88)
+        expect(result.rgb.g.round).to eql(88)
+        expect(result.rgb.b.round).to eql(86)
+      end
     end
   end
 end


### PR DESCRIPTION
When a HSL (or HSV I’d guess) have a `1%` component it was incorrectly converting the % to `100` as `to_percent` was not checking if the provided value was already a percent.

#2