### PR TITLE
Ruby version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         ruby-version: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
+        # CRuby < 2.6 does not support macos-arm64, so test those on amd64 instead
+        exclude:
+          - { os: macos-latest, ruby-version: '2.5' }
+        include:
+          - { os: macos-15-intel, ruby-version: '2.5' }
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['3.0', 2.7, 2.6, 2.5]
+        ruby-version: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Also quote all version numbers, not just 'x.0', for consistency.

The exclude / include configuration was taken from the output of a failed github actions run.

I'm sure we can drop ruby 2.5 in a future PR (support ended for that version back in 2021) but I wanted to make this PR as straightforward as possible!